### PR TITLE
Fix scheme name in README, add route example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,21 @@ server.register(hapiAuthFirebase, (err) => {
         throw err;
     }
     
-    server.auth.strategy('firebase', 'token', { 
+    server.auth.strategy('firebase', 'firebase', { 
         firebaseAdmin 
     });
+    
+    server.route({
+        path: '/session',
+        config: {
+            auth: 'firebase',
+        },
+        handler: function (request, reply) {
+            const name = request.auth.credentials.name;
+            reply('hello ' + name);
+        }
+    });
+
 });
 
 ```


### PR DESCRIPTION
IIUC the `scheme` name in the `README` example should match the registered scheme in the plugin, but wasn't.

Also added a dummy route example to show how to retrieve the credentials information.