### PR TITLE
Update plugin to work with Hapi v17

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,83 +1,28 @@
 'use strict';
 
-var raiseError = function () {
-  var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(errorFunc, errorContext) {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.next = 2;
-            return applyErrorFunc(errorFunc, errorContext);
+const { version } = require('../package.json');
+const Boom = require('boom');
 
-          case 2:
-            errorContext = _context.sent;
-            return _context.abrupt('return', Boom[errorContext.errorType](errorContext.message, errorContext.scheme, errorContext.attributes));
-
-          case 4:
-          case 'end':
-            return _context.stop();
-        }
-      }
-    }, _callee, this);
-  }));
-
-  return function raiseError(_x, _x2) {
-    return _ref.apply(this, arguments);
-  };
-}();
-
-var applyErrorFunc = function () {
-  var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(errorFunc, errorContext) {
-    return regeneratorRuntime.wrap(function _callee2$(_context2) {
-      while (1) {
-        switch (_context2.prev = _context2.next) {
-          case 0:
-            if (!errorFunc) {
-              _context2.next = 4;
-              break;
-            }
-
-            _context2.next = 3;
-            return errorFunc(errorContext);
-
-          case 3:
-            errorContext = _context2.sent;
-
-          case 4:
-            return _context2.abrupt('return', errorContext);
-
-          case 5:
-          case 'end':
-            return _context2.stop();
-        }
-      }
-    }, _callee2, this);
-  }));
-
-  return function applyErrorFunc(_x3, _x4) {
-    return _ref2.apply(this, arguments);
-  };
-}();
-
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
-var Boom = require('boom');
-
-module.exports = {
-  register,
-  raiseError,
-  applyErrorFunc,
-  firebaseAuthScheme,
-  authenticateRequest,
-  unauthorizedError,
-  verifyToken,
-  extractTokenFromRequest,
-  getCredentialFromAuthHeader
+exports.plugin = {
+  name: 'hapiAuthFirebase',
+  once: true,
+  pkg: require('../package.json'),
+  register: async (server, options) => {
+    return await server.auth.scheme('firebase', firebaseAuthScheme);
+  },
+  version: version
 };
 
-function register(server, options, next) {
-  server.auth.scheme('firebase', firebaseAuthScheme);
-  return next();
+async function raiseError(errorFunc, errorContext) {
+  errorContext = await applyErrorFunc(errorFunc, errorContext);
+  return Boom[errorContext.errorType](errorContext.message, errorContext.scheme, errorContext.attributes);
+}
+
+async function applyErrorFunc(errorFunc, errorContext) {
+  if (errorFunc) {
+    errorContext = await errorFunc(errorContext);
+  }
+  return errorContext;
 }
 
 function firebaseAuthScheme(server, options) {
@@ -87,66 +32,27 @@ function firebaseAuthScheme(server, options) {
 }
 
 function authenticateRequest(server, options) {
-  var _this = this;
+  return async (request, hapi) => {
+    const token = extractTokenFromRequest(request);
 
-  return function () {
-    var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3(request, reply) {
-      var token, credentials;
-      return regeneratorRuntime.wrap(function _callee3$(_context3) {
-        while (1) {
-          switch (_context3.prev = _context3.next) {
-            case 0:
-              token = extractTokenFromRequest(request);
+    if (!token) {
+      return hapi.unauthenticated(unauthorizedError(options.errorFunc));
+    }
 
-              if (token) {
-                _context3.next = 3;
-                break;
-              }
+    request.auth.token = token;
 
-              return _context3.abrupt('return', reply(unauthorizedError(options.errorFunc)));
-
-            case 3:
-
-              request.auth.token = token;
-
-              _context3.prev = 4;
-              _context3.next = 7;
-              return verifyToken(options.firebaseAdmin, token);
-
-            case 7:
-              credentials = _context3.sent;
-
-              reply.continue({
-                credentials,
-                artifacts: token
-              });
-              _context3.next = 14;
-              break;
-
-            case 11:
-              _context3.prev = 11;
-              _context3.t0 = _context3['catch'](4);
-              return _context3.abrupt('return', reply(unauthorizedError(options.errorFunc, {
-                message: _context3.t0.message || _context3.t0
-              })));
-
-            case 14:
-            case 'end':
-              return _context3.stop();
-          }
-        }
-      }, _callee3, _this, [[4, 11]]);
-    }));
-
-    return function (_x5, _x6) {
-      return _ref3.apply(this, arguments);
-    };
-  }();
+    try {
+      const credentials = await verifyToken(options.firebaseAdmin, token);
+      return hapi.authenticated({ credentials: credentials, artifacts: token });
+    } catch (error) {
+      return hapi.unauthenticated(unauthorizedError(options.errorFunc, {
+        message: error.message || error
+      }));
+    }
+  };
 }
 
-function unauthorizedError(errorFunc) {
-  var errorParams = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+function unauthorizedError(errorFunc, errorParams = {}) {
   return raiseError(errorFunc, Object.assign({}, errorParams, {
     errorType: 'unauthorized',
     scheme: 'firebase'
@@ -164,7 +70,3 @@ function extractTokenFromRequest(request) {
 function getCredentialFromAuthHeader(scheme, header) {
   return (header.match(new RegExp(`${scheme} (.*)`)) || [])[1];
 }
-
-register.attributes = {
-  pkg: require('../package.json')
-};

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -2,34 +2,15 @@
 
 var _index = require('./index');
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
-describe('hapi-auth-firebase', function () {
-  it('should register auth scheme', _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-    var server, next;
-    return regeneratorRuntime.wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            // register(server, options, next)
-            server = {
-              auth: {
-                scheme: jest.fn()
-              }
-            };
-            next = jest.fn();
-            _context.next = 4;
-            return (0, _index.register)(server, {}, next);
-
-          case 4:
-            expect(server.auth.scheme).toHaveBeenCalled();
-            expect(next).toHaveBeenCalled();
-
-          case 6:
-          case 'end':
-            return _context.stop();
-        }
+describe('hapi-auth-firebase', () => {
+  it('should register auth scheme', async () => {
+    // plugin.register(server, options)
+    const server = {
+      auth: {
+        scheme: jest.fn()
       }
-    }, _callee, undefined);
-  })));
+    };
+    await _index.plugin.register(server, {});
+    expect(server.auth.scheme).toHaveBeenCalled();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-firebase",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Denes Pal <dsdenes@gmail.com>",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,26 +1,16 @@
 import {
-  register,
-  raiseError,
-  applyErrorFunc,
-  firebaseAuthScheme,
-  authenticateRequest,
-  unauthorizedError,
-  verifyToken,
-  extractTokenFromRequest,
-  getCredentialFromAuthHeader
+  plugin
 } from './index';
 
 describe('hapi-auth-firebase', () => {
   it('should register auth scheme', async () => {
-    // register(server, options, next)
+    // plugin.register(server, options)
     const server = {
       auth: {
         scheme: jest.fn()
       }
     };
-    const next = jest.fn();
-    await register(server, {}, next);
+    await plugin.register(server, {});
     expect(server.auth.scheme).toHaveBeenCalled();
-    expect(next).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
As I'm sure you're aware Hapi v17 contains breaking changes for plugins and auth as well as the depreciation of callbacks and the introduction of async-await support. This PR includes changes that bring hapi-auth-firebase current with Hapi v17. 

- Version bump to 1.1.0 (or whatever you think the next version should be)

- Update the plugin registration signature to conform to v17 API 
[plugins](https://github.com/hapijs/hapi/blob/083c7b1536019b678fc7d43fa5ecb90ff8078ac3/API.md#plugins)
[server.register()](https://github.com/hapijs/hapi/blob/083c7b1536019b678fc7d43fa5ecb90ff8078ac3/API.md#server.register())

- Update Auth scheme to work with new v17 API
[server.auth.scheme()](https://github.com/hapijs/hapi/blob/083c7b1536019b678fc7d43fa5ecb90ff8078ac3/API.md#server.auth.scheme())
[h.unauthenticated()](https://github.com/hapijs/hapi/blob/083c7b1536019b678fc7d43fa5ecb90ff8078ac3/API.md#h.unauthenticated())

- Update tests to conform to v17 plugin.register() API
-- drop callback from register function

